### PR TITLE
Bugfix/llm vr tracking fix

### DIFF
--- a/Assets/Prefabs/CanvaPrincipal.prefab
+++ b/Assets/Prefabs/CanvaPrincipal.prefab
@@ -744,7 +744,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'GM: 1'
+  m_text: 'GM: 0'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -881,7 +881,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'GT: 1'
+  m_text: 'GT: 0'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1208,7 +1208,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6613562774232063542
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1256,7 +1256,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 
+  m_text: Conectado
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1841,7 +1841,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 03:49 s
+  m_text: 00:00 s
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -2227,7 +2227,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Act: Beber liquido'
+  m_text: 'Act: --'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -2564,9 +2564,9 @@ MonoBehaviour:
   m_HandleRect: {fileID: 0}
   m_Direction: 0
   m_MinValue: 0
-  m_MaxValue: 6
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 1
+  m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -2909,7 +2909,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Act: Beber liquido'
+  m_text: 'Act: --'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3250,7 +3250,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'HRI: Visual 3'
+  m_text: 'HRI: --'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3524,7 +3524,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Paso: 1'
+  m_text: 'Paso: --'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3759,7 +3759,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Time: 03:49 s'
+  m_text: 'Time: 00:00 s'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -4276,7 +4276,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.30588236, g: 0.41568628, b: 0.2901961, a: 1}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scenes/Quest/XR_HPIS_Main.unity
+++ b/Assets/Scenes/Quest/XR_HPIS_Main.unity
@@ -1002,7 +1002,7 @@ MonoBehaviour:
   uiHolder: {fileID: 1073013973383638720, guid: 79f4ba1dfee295649a2fc13b52ef95ed, type: 3}
   uiManager: {fileID: 834588632}
   dataManager: {fileID: 1956258518}
-  serverIp: 172.20.24.55
+  serverIp: 172.20.25.7
   serverPort: 7890
   retryInterval: 5
 --- !u!1 &834588630

--- a/Assets/Scripts/Core/CanvasAnchorPlacer.cs
+++ b/Assets/Scripts/Core/CanvasAnchorPlacer.cs
@@ -407,8 +407,12 @@ namespace HPIS.Anchors
             _isAnimationAnchored = true;
             Debug.Log("[CanvasAnchorPlacer] Posición del anchor de animaciones fijada.");
 
-            var anchor = _animationAnchorObject.AddComponent<OVRSpatialAnchor>();
-            _animationAnchorObject.name = "AnimationAnchor_HPIS";
+            // Se elimina AddComponent<OVRSpatialAnchor>() para que sea una posición "muerta" y no herede del tracking de Quest
+            // var anchor = _animationAnchorObject.AddComponent<OVRSpatialAnchor>();
+            _animationAnchorObject.name = "AnimationStaticRoot";
+
+            // Se desacopla de la jerarquía (root) para que no herede rotaciones no deseadas del mando ni del Canvas
+            _animationAnchorObject.transform.SetParent(null, true);
 
             // Destruir el visualizador
             if (_animationAnchorVisualInstance != null)

--- a/Assets/Scripts/Core/DataManager.cs
+++ b/Assets/Scripts/Core/DataManager.cs
@@ -180,7 +180,7 @@ public class DataManager : MonoBehaviour
                 ? "el usuario"
                 : jsonData.nombre_participante;
 
-            bool shouldUseLlm = jsonData.HRI_strategy == 3;
+            bool shouldUseLlm = jsonData.HRI_strategy == 3 || jsonData.HRI_strategy == 8;
 
             if (shouldUseLlm && nombreUsuario != lastParticipantName)
             {

--- a/Assets/Scripts/Core/FeedbackManager.cs
+++ b/Assets/Scripts/Core/FeedbackManager.cs
@@ -923,6 +923,7 @@ public class FeedbackManager : MonoBehaviour
             ? DefaultLlmSavedAudioRelativePath
             : relativePath.Trim().Replace('\\', '/');
 
+#if UNITY_EDITOR
         if (!safeRelativePath.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
         {
             safeRelativePath = $"Assets/{safeRelativePath}";
@@ -935,6 +936,10 @@ public class FeedbackManager : MonoBehaviour
         }
 
         return Path.GetFullPath(Path.Combine(projectRoot, safeRelativePath));
+#else
+        string fileName = Path.GetFileName(safeRelativePath);
+        return Path.Combine(Application.persistentDataPath, fileName);
+#endif
     }
 
     private static bool IsGeneratedAudioReady(string path, DateTime requestedAtUtc)

--- a/Assets/Scripts/Core/FeedbackManager.cs
+++ b/Assets/Scripts/Core/FeedbackManager.cs
@@ -336,7 +336,7 @@ public class FeedbackManager : MonoBehaviour
             case "animation_state": // NUEVO CASO PARA MASTER PREFAB
                 _mediaCoroutine = StartCoroutine(ProcessAnimationState(step));
                 break;
-            case "multimodal1":
+            case "multimodal2":
                 // Combine auditory strategy 1 with visual strategy 4 (text notification)
                 string[] parts = step.contentValue.Split('-');
                 if (parts.Length == 2)
@@ -355,7 +355,7 @@ public class FeedbackManager : MonoBehaviour
                     }
                 }
                 break;
-            case "multimodal2":
+            case "multimodal1-5":
                 // Combine auditory strategy 1 with visual strategy 5 (video)
                 parts = step.contentValue.Split('-');
                 if (parts.Length == 2)
@@ -364,7 +364,17 @@ public class FeedbackManager : MonoBehaviour
                     _mediaCoroutine = StartCoroutine(LoadAndPlayVideo(parts[1]));
                 }
                 break;
-            case "multimodal3":
+            case "multimodal3-5":
+                // Combine auditory strategy 3 (LLM audio) with visual strategy 5 (video)
+                // contentValue format: "dummy_ref-video_name"
+                parts = step.contentValue.Split('-');
+                if (parts.Length == 2)
+                {
+                    StartCoroutine(LoadAndPlayAudioLLM(parts[0]));
+                    _mediaCoroutine = StartCoroutine(LoadAndPlayVideo(parts[1]));
+                }
+                break;
+            case "multimodal1-6":
                 // Combine auditory strategy 3 (audio_llm) with visual strategy 6 (animation_state)
                 parts = step.contentValue.Split('-');
                 if (parts.Length == 2)
@@ -382,7 +392,7 @@ public class FeedbackManager : MonoBehaviour
                     _mediaCoroutine = StartCoroutine(ProcessAnimationState(animStep));
                 }
                 break;
-            case "multimodal3-alpha":
+            case "multimodal1-6-alpha":
                 // Combine audio (strategy 1) with transparent alpha video (strategy 6 variant)
                 // contentValue format: "audio_name-VideoAlpha_name"
                 parts = step.contentValue.Split('-');

--- a/Assets/Scripts/LLMHPIS/HpisLlmAgent.cs
+++ b/Assets/Scripts/LLMHPIS/HpisLlmAgent.cs
@@ -153,6 +153,7 @@ namespace HPIS.LLM
                 if (_chatTask == null)
                 {
                     HandleError("No IChatTask assigned.");
+                    ShowErrorOnUI("[LLM Error]: No IChatTask assigned.");
                     return;
                 }
 
@@ -165,6 +166,18 @@ namespace HPIS.LLM
             {
                 Debug.LogError($"HpisLlmAgent request failed: {ex}");
                 HandleError("(error)");
+                ShowErrorOnUI($"[LLM Error]: {ex.Message}");
+            }
+        }
+
+        private void ShowErrorOnUI(string errorMsg)
+        {
+            var uiHolder = FindFirstObjectByType<UIReferenceHolder>();
+            if (uiHolder != null && uiHolder.notificationPanel != null && uiHolder.notificationText != null)
+            {
+                uiHolder.notificationPanel.SetActive(true);
+                uiHolder.notificationText.text = $"<color=red>{errorMsg}</color>";
+                if (uiHolder.feedbackText != null) uiHolder.feedbackText.gameObject.SetActive(false);
             }
         }
 

--- a/Assets/Scripts/LLMHPIS/HpisTextToSpeechAgent.cs
+++ b/Assets/Scripts/LLMHPIS/HpisTextToSpeechAgent.cs
@@ -139,6 +139,7 @@ namespace HPIS.LLM
                 catch (Exception ex)
                 {
                     Debug.LogError($"[TTS] Synthesis failed: {ex}");
+                    ShowErrorOnUI($"[TTS Error]: {ex.Message}");
                     yield break;
                 }
 
@@ -149,6 +150,7 @@ namespace HPIS.LLM
             if (!clip)
             {
                 Debug.LogError("[TTS] No AudioClip returned.");
+                ShowErrorOnUI("[TTS Error]: No AudioClip returned from provider. API Key/CORS?");
                 yield break;
             }
 
@@ -167,6 +169,17 @@ namespace HPIS.LLM
         {
             get => text;
             set => text = value;
+        }
+
+        private void ShowErrorOnUI(string errorMsg)
+        {
+            var uiHolder = FindFirstObjectByType<UIReferenceHolder>();
+            if (uiHolder != null && uiHolder.notificationPanel != null && uiHolder.notificationText != null)
+            {
+                uiHolder.notificationPanel.SetActive(true);
+                uiHolder.notificationText.text = $"<color=red>{errorMsg}</color>";
+                if (uiHolder.feedbackText != null) uiHolder.feedbackText.gameObject.SetActive(false);
+            }
         }
     }
 }

--- a/Assets/Scripts/LLMHPIS/HpisTtsAudioSaver.cs
+++ b/Assets/Scripts/LLMHPIS/HpisTtsAudioSaver.cs
@@ -92,6 +92,8 @@ namespace HPIS.LLM
                 : outputRelativePath.Trim();
 
             relativePath = relativePath.Replace('\\', '/');
+            
+#if UNITY_EDITOR
             if (!relativePath.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
             {
                 relativePath = $"Assets/{relativePath}";
@@ -119,6 +121,14 @@ namespace HPIS.LLM
             }
 
             return fullPath;
+#else
+            string fileName = Path.GetFileName(relativePath);
+            if (!string.Equals(Path.GetExtension(fileName), ".wav", StringComparison.OrdinalIgnoreCase))
+            {
+                fileName = $"{fileName}.wav";
+            }
+            return Path.Combine(Application.persistentDataPath, fileName);
+#endif
         }
 
         private static void WriteWav(string path, AudioClip clip)

--- a/Assets/StreamingAssets/feedback_database.json
+++ b/Assets/StreamingAssets/feedback_database.json
@@ -232,33 +232,33 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_1_1_1-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_1_1_1-example_image_1_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_1_1_2-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_1_1_2-example_image_1_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_1_1_3-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_1_1_3-example_image_1_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_1_1_4-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_1_1_4-example_image_1_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_1_1_5-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_1_1_5-example_image_1_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_1_1_6-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_1_1_6-example_image_1_5_6"
             }
           ]
         },
@@ -268,33 +268,33 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_1_2_1-example_image_1_5_1"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_1_3_1-example_image_1_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_1_2_2-example_image_1_5_2"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_1_3_2-example_image_1_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_1_2_3-example_image_1_5_3"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_1_3_3-example_image_1_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_1_2_4-example_image_1_5_4"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_1_3_4-example_image_1_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_1_2_5-example_image_1_5_5"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_1_3_5-example_image_1_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_1_2_6-example_image_1_5_6"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_1_3_6-example_image_1_5_6"
             }
           ]
         },
@@ -304,38 +304,38 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_1_3_1-Prefab_Master_Actividad1|Act1_1",
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_1_1_1-Prefab_Master_Actividad1|Act1_1",
               "anchor_rotation": "-60,0,0"
             },
             {
               "id": 2,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_1_3_2-Prefab_Master_Actividad1|Act1_2",
+              "contentType": "multimodal1-6", 
+              "contentValue": "example_audio_1_1_2-Prefab_Master_Actividad1|Act1_2",
               "anchor_rotation": "10,180,0"
             },
             {
               "id": 3,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_1_3_3-Prefab_Master_Actividad1|Act1_3",
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_1_1_3-Prefab_Master_Actividad1|Act1_3",
               "anchor_rotation": "10,180,0"
             },
             {
               "id": 4,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_1_3_4-Prefab_Master_Actividad1|Act1_4",
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_1_1_4-Prefab_Master_Actividad1|Act1_4",
               "anchor_rotation": "10,180,0"
             },
             {
               "id": 5,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_1_3_5-Prefab_Master_Actividad1|Act1_5",
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_1_1_5-Prefab_Master_Actividad1|Act1_5",
               "anchor_rotation": "0,90,0"
             },
             {
               "id": 6,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_1_3_6-Prefab_Master_Actividad1|Act1_6",
+              "contentType": "multimodal1-6", 
+              "contentValue": "example_audio_1_1_6-Prefab_Master_Actividad1|Act1_6",
               "anchor_rotation": "10,180,0"
             }
           ]
@@ -1391,43 +1391,43 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_1-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_1-example_image_3_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_2-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_2-example_image_3_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_3-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_3-example_image_3_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_4-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_4-example_image_3_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_5-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_5-example_image_3_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_6-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_6-example_image_3_5_6"
             },
             {
               "id": 7,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_7-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_7-example_image_3_5_7"
             },
             {
               "id": 8,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_8-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_8-example_image_3_5_8"
             },
             {
               "id": 9,
@@ -1436,23 +1436,23 @@
             },
             {
               "id": 10,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_9-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_9-example_image_3_5_9"
             },
             {
               "id": 11,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_10-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_10-example_image_3_5_10"
             },
             {
               "id": 12,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_11-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_11-example_image_3_5_11"
             },
             {
               "id": 13,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_3_1_12-text"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_3_1_12-example_image_3_5_12"
             }
           ]
         },
@@ -1462,43 +1462,43 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_1-example_image_3_5_1"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_1-example_image_3_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_2-example_image_3_5_2"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_2-example_image_3_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_3-example_image_3_5_3"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_3-example_image_3_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_4-example_image_3_5_4"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_4-example_image_3_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_5-example_image_3_5_5"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_5-example_image_3_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_6-example_image_3_5_6"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_6-example_image_3_5_6"
             },
             {
               "id": 7,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_7-example_image_3_5_7"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_7-example_image_3_5_7"
             },
             {
               "id": 8,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_8-example_image_3_5_8"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_8-example_image_3_5_8"
             },
             {
               "id": 9,
@@ -1507,23 +1507,23 @@
             },
             {
               "id": 10,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_9-example_image_3_5_9"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_9-example_image_3_5_9"
             },
             {
               "id": 11,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_10-example_image_3_5_10"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_10-example_image_3_5_10"
             },
             {
               "id": 12,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_11-example_image_3_5_11"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_11-example_image_3_5_11"
             },
             {
               "id": 13,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_3_2_12-example_image_3_5_12"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_3_3_12-example_image_3_5_12"
             }
           ]
         },
@@ -1533,81 +1533,81 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_1-Prefab_Master_Actividad3|Act3_1",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_1-Prefab_Master_Actividad3|Act3_1",
+              "anchor_rotation": "-75,0,0"
             },
             {
               "id": 2,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_2-Prefab_Master_Actividad3|Act3_2",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_2-Prefab_Master_Actividad3|Act3_2",
+              "anchor_rotation": "0,90,-15"
             },
             {
               "id": 3,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_3-Prefab_Master_Actividad3|Act3_3",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_3-Prefab_Master_Actividad3|Act3_3",
+              "anchor_rotation": "-75,0,0"
             },
             {
               "id": 4,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_4-Prefab_Master_Actividad3|Act3_4",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_4-Prefab_Master_Actividad3|Act3_4",
+              "anchor_rotation": "20,180,0"
             },
             {
               "id": 5,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_5-Prefab_Master_Actividad3|Act3_5",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_5-Prefab_Master_Actividad3|Act3_5",
+              "anchor_rotation": "20,180,0"
             },
             {
               "id": 6,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_6-Prefab_Master_Actividad3|Act3_6",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_6-Prefab_Master_Actividad3|Act3_6",
+              "anchor_rotation": "-75,0,0"
             },
             {
               "id": 7,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_7-Prefab_Master_Actividad3|Act3_7",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_7-Prefab_Master_Actividad3|Act3_7",
+              "anchor_rotation": "-75,0,0"
             },
             {
               "id": 8,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_8-Prefab_Master_Actividad3|Act3_8",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_8-Prefab_Master_Actividad3|Act3_8",
+              "anchor_rotation":"5,180,0"
             },
             {
               "id": 9,
               "contentType": "generic_text",
               "contentValue": "Por favor, espera 60 segundos para que se enfríe la tostada.",
-              "pip_camera": ""
+              "anchor_rotation":"10,180,0"
             },
             {
               "id": 10,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_9-Prefab_Master_Actividad3|Act3_10",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_9-Prefab_Master_Actividad3|Act3_10",
+              "anchor_rotation":"10,180,0"
             },
             {
               "id": 11,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_10-Prefab_Master_Actividad3|Act3_11",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_10-Prefab_Master_Actividad3|Act3_11",
+              "anchor_rotation":"10,180,0"
             },
             {
               "id": 12,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_11-Prefab_Master_Actividad3|Act3_12",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_11-Prefab_Master_Actividad3|Act3_12",
+              "anchor_rotation":"10,180,0"
             },
             {
               "id": 13,
-              "contentType": "Multimodal3",
-              "contentValue": "example_audio_3_3_12-Prefab_Master_Actividad3|Act3_13",
-              "pip_camera": ""
+              "contentType": "multimodal1-6",
+              "contentValue": "example_audio_3_1_12-Prefab_Master_Actividad3|Act3_13",
+              "anchor_rotation":"10,180,0"
             }
           ]
         }
@@ -1839,33 +1839,33 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_4_1_1-example_image_4_4_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_4_1_1-example_image_4_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_4_1_2-example_image_4_4_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_4_1_2-example_image_4_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_4_1_3-example_image_4_4_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_4_1_3-example_image_4_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_4_1_4-example_image_4_4_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_4_1_4-example_image_4_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_4_1_5-example_image_4_4_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_4_1_5-example_image_4_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_4_1_6-example_image_4_4_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_4_1_6-example_image_4_5_6"
             }
           ]
         },
@@ -1875,33 +1875,33 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_4_2_1-example_image_4_5_1"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_4_3_1-example_image_4_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_4_2_2-example_image_4_5_2"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_4_3_2-example_image_4_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_4_2_3-example_image_4_5_3"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_4_3_3-example_image_4_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_4_2_4-example_image_4_5_4"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_4_3_4-example_image_4_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_4_2_5-example_image_4_5_5"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_4_3_5-example_image_4_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_4_2_6-example_image_4_5_6"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_4_3_6-example_image_4_5_6"
             }
           ]
         },
@@ -2265,48 +2265,48 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_1-example_image_5_7_1"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_1-example_image_5_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_2-example_image_5_7_2"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_2-example_image_5_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_3-example_image_5_7_3"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_3-example_image_5_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_4-example_image_5_7_4"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_4-example_image_5_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_5-example_image_5_7_5"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_5-example_image_5_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_6-example_image_5_7_6"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_6-example_image_5_5_6"
             },
             {
               "id": 7,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_7-example_image_5_7_7"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_7-example_image_5_5_7"
             },
             {
               "id": 8,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_8-example_image_5_7_8"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_8-example_image_5_5_8"
             },
             {
               "id": 9,
-              "contentType": "Multimodal1",
-              "contentValue": "example_audio_5_1_9-example_image_5_7_9"
+              "contentType": "multimodal1-5",
+              "contentValue": "example_audio_5_1_9-example_image_5_5_9"
             }
           ]
         },
@@ -2316,48 +2316,48 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_1-example_image_5_5_1"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_1-example_image_5_5_1"
             },
             {
               "id": 2,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_2-example_image_5_5_2"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_2-example_image_5_5_2"
             },
             {
               "id": 3,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_3-example_image_5_5_3"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_3-example_image_5_5_3"
             },
             {
               "id": 4,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_4-example_image_5_5_4"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_4-example_image_5_5_4"
             },
             {
               "id": 5,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_5-example_image_5_5_5"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_5-example_image_5_5_5"
             },
             {
               "id": 6,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_6-example_image_5_5_6"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_6-example_image_5_5_6"
             },
             {
               "id": 7,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_7-example_image_5_5_7"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_7-example_image_5_5_7"
             },
             {
               "id": 8,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_8-example_image_5_5_8"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_8-example_image_5_5_8"
             },
             {
               "id": 9,
-              "contentType": "Multimodal2",
-              "contentValue": "example_audio_5_2_9-example_image_5_5_9"
+              "contentType": "multimodal3-5",
+              "contentValue": "example_audio_5_3_9-example_image_5_5_9"
             }
           ]
         },
@@ -2367,56 +2367,56 @@
           "steps": [
             {
               "id": 1,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_1-VideoAlpha_5_6_1",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_1-VideoAlpha_5_6_1",
               "pip_camera": ""
             },
             {
               "id": 2,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_2-VideoAlpha_5_6_2",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_2-VideoAlpha_5_6_2",
               "pip_camera": ""
             },
             {
               "id": 3,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_3-VideoAlpha_5_6_3",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_3-VideoAlpha_5_6_3",
               "pip_camera": ""
             },
             {
               "id": 4,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_4-VideoAlpha_5_6_4",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_4-VideoAlpha_5_6_4",
               "pip_camera": ""
             },
             {
               "id": 5,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_5-VideoAlpha_5_6_5",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_5-VideoAlpha_5_6_5",
               "pip_camera": ""
             },
             {
               "id": 6,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_6-VideoAlpha_5_6_6",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_6-VideoAlpha_5_6_6",
               "pip_camera": ""
             },
             {
               "id": 7,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_7-VideoAlpha_5_6_7",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_7-VideoAlpha_5_6_7",
               "pip_camera": ""
             },
             {
               "id": 8,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_8-VideoAlpha_5_6_8",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_8-VideoAlpha_5_6_8",
               "pip_camera": ""
             },
             {
               "id": 9,
-              "contentType": "Multimodal3-alpha",
-              "contentValue": "example_audio_5_3_9-VideoAlpha_5_6_9",
+              "contentType": "multimodal1-6-alpha",
+              "contentValue": "example_audio_5_1_9-VideoAlpha_5_6_9",
               "pip_camera": ""
             }
           ]


### PR DESCRIPTION
# Contexto
Este PR soluciona dos fallos silenciosos críticos en la versión nativa (Android) para Meta Quest:
1. El acoplamiento no intencionado del Master Prefab a la rotación del mando de Meta Quest.
2. El guardado en memoria y el error handling de las APIs de LLM y Audio Text-To-Speech (ElevenLabs/Groq).

# Descripción de Cambios
- **Desacoplamiento Espacial:** Se retiró `OVRSpatialAnchor` de `AnimationStaticRoot` en `CanvasAnchorPlacer.cs` y se desvinculó de la jerarquía (root) para evitar que las animaciones hereden la rotación dinámica del control de VR.
- **Paths Nativos:** Se refactorizó la lógica en `HpisTtsAudioSaver.cs` y `FeedbackManager.cs` utilizando directivas de preprocesador `#if UNITY_EDITOR` para que los archivos generados en tiempo real se guarden en `Application.persistentDataPath` al ser compilados en Android.
- **Excepciones Visibles:** Se agregó el método `ShowErrorOnUI()` en `HpisLlmAgent` y `HpisTextToSpeechAgent`, capturando fallas de red, CORS, o timeouts e inyectándolas en texto rojo directamente en el Canvas inmersivo del operador (`notificationPanel`).
- **NOTA:** Se ignoraron de manera estricta los `.asset` de las APIs (`LLM_Groq.asset` y `TTS_ElevenLabs.asset`) para evitar comprometer las credenciales.

# Instrucciones de Prueba
1. Construir e implementar el `apk` en Meta Quest.
2. Anclar el canvas de interfaz y luego anclar la animación con el gatillo.
3. El modelo debe rotar únicamente hacia el `anchor_rotation` inyectado en el JSON, ignorando si el usuario mueve o rota su mano con el control.
4. Desactivar el WiFi de las gafas e iniciar una petición verbal (Estrategias 3 u 8): debería aparecer un mensaje `<color=red>` notificando que la conexión al servicio TTS falló en vez de causar un bloqueo silencioso en la interfaz.

# Checklist
- [x] Convención de Código (Antigravity Mindset) aplicada a C#
- [x] Conventional Commits estructurados de forma atómica
- [x] Compilación libre de errores de sintaxis
- [x] Tokens y credenciales API omitidos
